### PR TITLE
Add support for docker doc generation (both Docker Readme for Docker repo and SAG doc) based on templates

### DIFF
--- a/src/main/java/org/terracotta/build/plugins/docker/DockerBuildExtension.java
+++ b/src/main/java/org/terracotta/build/plugins/docker/DockerBuildExtension.java
@@ -39,4 +39,9 @@ public abstract class DockerBuildExtension {
   public abstract MapProperty<String, String> getMetadata();
 
   public abstract RegularFileProperty getDockerReadme();
+
+  public abstract DirectoryProperty getDocTemplates();
+  public abstract MapProperty<String, Object> getDocMetadata();
+
+  public abstract DirectoryProperty getSagDocDirectory();
 }


### PR DESCRIPTION
- `gw dockerProcessReadme`: does the same thing as before, but based on templates
- `gw dockerProcessSagDoc`: will generate acr-data content based on templates

Next step will be to see with iBit / doc teams how to change the format / structure of the acr-data content so that we can embed that in our containers