### PR TITLE
Fixed BuildInfoPlugin class

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,7 @@ gradlePlugin {
     }
     buildInfo {
       id = 'org.terracotta.build.build-info'
-      implementationClass = 'org.terracotta.build.plugins.BuildInfoPlugin'
+      implementationClass = 'org.terracotta.build.plugins.buildinfo.BuildInfoPlugin'
     }
   }
 }


### PR DESCRIPTION
Leads to this warning when doing a `gw test`:

`:jar: A valid plugin descriptor was found for org.terracotta.build.build-info.properties but the implementation class org.terracotta.build.plugins.BuildInfoPlugin was not found in the jar.
`