### PR TITLE
Fix Gradle duplicate jar failure when adding a test entity having a dependency already in the kit

### DIFF
--- a/src/main/java/org/terracotta/build/plugins/AbstractKitTestingPlugin.java
+++ b/src/main/java/org/terracotta/build/plugins/AbstractKitTestingPlugin.java
@@ -111,6 +111,9 @@ public abstract class AbstractKitTestingPlugin implements Plugin<Project> {
             fcd.exclude();
           }
         });
+        spec.filesMatching("**/*.jar", fcd -> {
+          fcd.setDuplicatesStrategy(DuplicatesStrategy.EXCLUDE);
+        });
       });
     });
 


### PR DESCRIPTION
Error example:

```
* What went wrong:
Execution failed for task ':system-tests:management:galvanKitPreparation'.
> Entry server/plugins/lib/voltron-proxy-server-5.10-SNAPSHOT.jar is a duplicate but no duplicate handling strategy has been set. Please refer to https://docs.gradle.org/8.4/dsl/org.gradle.api.tasks.Copy.html#org.gradle.api.tasks.Copy:duplicatesStrategy for details.
```