### PR TITLE
support older versions of gradle

### DIFF
--- a/src/main/java/org/terracotta/build/plugins/VoltronPlugin.java
+++ b/src/main/java/org/terracotta/build/plugins/VoltronPlugin.java
@@ -94,7 +94,7 @@ public class VoltronPlugin implements Plugin<Project> {
       config.setCanBeResolved(true);
       config.setCanBeConsumed(true);
     });
-    project.getConfigurations().named(JavaPlugin.API_CONFIGURATION_NAME, config -> config.extendsFrom(service.get()));
+    project.getConfigurations().named(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME, config -> config.extendsFrom(service.get()));
     project.getConfigurations().named(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME, config -> config.extendsFrom(voltron.get()));
     project.getConfigurations().named(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME, config -> config.extendsFrom(voltron.get()));
 


### PR DESCRIPTION
Older gradle doesn't have "JavaLanguageVersion.current()". This seems like a reasonable substitute.
